### PR TITLE
Refractor/weighted completetion time

### DIFF
--- a/crates/bollard-bnb/benches/bnb_opening_benchmark.rs
+++ b/crates/bollard-bnb/benches/bnb_opening_benchmark.rs
@@ -21,7 +21,7 @@
 
 use bollard_bnb::{
     bnb::BnbSolver, branching::edf::EarliestDeadlineFirstBuilder,
-    eval::wtft::WeightedFlowTimeEvaluator, monitor::solution::SolutionLimitMonitor,
+    eval::wct::WeightedCompletionTimeEvaluator, monitor::solution::SolutionLimitMonitor,
     params::BnbSearchParams,
 };
 use bollard_model::{loading::ProblemLoader, model::Model};
@@ -97,7 +97,7 @@ fn benchmark_edf(c: &mut Criterion) {
             b.iter(|| {
                 let mut solver: BnbSolver<i64> = BnbSolver::new();
                 let mut builder = EarliestDeadlineFirstBuilder::<i64>::new();
-                let mut evaluator = WeightedFlowTimeEvaluator::<i64>::new();
+                let mut evaluator = WeightedCompletionTimeEvaluator::<i64>::new();
                 let monitor = SolutionLimitMonitor::<i64>::new(1);
 
                 let params =

--- a/crates/bollard-bnb/benches/bnb_opening_benchmark.rs
+++ b/crates/bollard-bnb/benches/bnb_opening_benchmark.rs
@@ -20,9 +20,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use bollard_bnb::{
-    bnb::BnbSolver, branching::edf::EarliestDeadlineFirstBuilder,
-    eval::wct::WeightedCompletionTimeEvaluator, monitor::solution::SolutionLimitMonitor,
-    params::BnbSearchParams,
+    bnb::BnbSolver, branching::edf::EdfHeuristic, eval::wct::WeightedCompletionTimeEvaluator,
+    monitor::solution::SolutionLimitMonitor, params::BnbSearchParams,
 };
 use bollard_model::{loading::ProblemLoader, model::Model};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -96,7 +95,7 @@ fn benchmark_edf(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("edf", file_name), &path, |b, _| {
             b.iter(|| {
                 let mut solver: BnbSolver<i64> = BnbSolver::new();
-                let mut builder = EarliestDeadlineFirstBuilder::<i64>::new();
+                let mut builder = EdfHeuristic::<i64>::new();
                 let mut evaluator = WeightedCompletionTimeEvaluator::<i64>::new();
                 let monitor = SolutionLimitMonitor::<i64>::new(1);
 

--- a/crates/bollard-bnb/src/bnb.rs
+++ b/crates/bollard-bnb/src/bnb.rs
@@ -478,7 +478,7 @@ where
     /// Initialize the search session.
     ///
     /// This sets up the initial trail and stack frames,
-    /// makes sure we have enaugh memory allocated to *not*
+    /// makes sure we have enough memory allocated to *not*
     /// resize during the search, and pushes the first decisions
     /// onto the stack.
     #[inline]
@@ -779,16 +779,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::branching::edf::EarliestDeadlineFirstBuilder;
-    use crate::branching::regret::RegretHeuristicBuilder;
-    use crate::branching::wspt::WsptHeuristicBuilder;
+    use crate::branching::edf::EdfHeuristic;
+    use crate::branching::regret::RegretBuilder;
+    use crate::branching::wspt::WsptBuilder;
     use crate::eval::hybrid::HybridEvaluator;
     use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use crate::monitor::no_op::NoOperationMonitor;
     use crate::monitor::solution::SolutionLimitMonitor;
     use crate::{
-        branching::chronological::ChronologicalExhaustiveBuilder,
-        monitor::log::LogTreeSearchMonitor,
+        branching::chronological::ChronologicalBuilder, monitor::log::LogTreeSearchMonitor,
     };
     use bollard_core::math::interval::ClosedOpenInterval;
     use bollard_model::{
@@ -807,10 +806,7 @@ mod tests {
     /// - Processing times:
     ///   - Berth 0: 10..12 depending on vessel index
     ///   - Berth 1: 7..10 depending on vessel index
-    fn build_model(
-        num_berths: usize,
-        num_vessels: usize,
-    ) -> bollard_model::model::Model<IntegerType> {
+    fn build_model(num_berths: usize, num_vessels: usize) -> Model<IntegerType> {
         let mut builder = ModelBuilder::<IntegerType>::new(num_berths, num_vessels);
 
         // Simple arrivals and weights
@@ -845,8 +841,7 @@ mod tests {
 
         let mut evaluator =
             HybridEvaluator::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut edf_builder =
-            EarliestDeadlineFirstBuilder::preallocated(model.num_berths(), model.num_vessels());
+        let mut edf_builder = EdfHeuristic::preallocated(model.num_berths(), model.num_vessels());
 
         // Build search params via builder (no fixed, no initial solution)
         let params = BnbSearchParams::builder(
@@ -865,8 +860,7 @@ mod tests {
             initial.result().unwrap().objective_value()
         );
 
-        let mut builder =
-            WsptHeuristicBuilder::preallocated(model.num_berths(), model.num_vessels());
+        let mut builder = WsptBuilder::preallocated(model.num_berths(), model.num_vessels());
 
         // Run the solver using the params builder with an initial solution
         let outcome = solver.solve(
@@ -929,7 +923,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -975,7 +969,7 @@ mod tests {
 
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1026,7 +1020,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1084,7 +1078,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1135,7 +1129,7 @@ mod tests {
 
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1218,7 +1212,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1280,7 +1274,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1330,7 +1324,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1372,7 +1366,7 @@ mod tests {
 
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         for run in 0..2 {
             let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
@@ -1434,7 +1428,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
@@ -1486,7 +1480,7 @@ mod tests {
 
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         for run in 0..3 {
             let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
@@ -1550,7 +1544,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
@@ -1641,7 +1635,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1685,7 +1679,7 @@ mod tests {
 
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         for i in 0..3 {
             let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
@@ -1732,7 +1726,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1788,7 +1782,7 @@ mod tests {
         let model = builder.build();
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::default();
 
         let outcome = solver.solve(
@@ -1818,7 +1812,7 @@ mod tests {
         let model = build_model(2, 8);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator_cold = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1929,7 +1923,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -1984,7 +1978,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2021,7 +2015,7 @@ mod tests {
         );
         assert!(
             stats.prunings_bound + stats.prunings_infeasible <= stats.nodes_explored,
-            "total prunings should not exceed explored nodes"
+            "total pruning should not exceed explored nodes"
         );
     }
 
@@ -2032,7 +2026,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2088,7 +2082,7 @@ mod tests {
     fn test_reset_mid_session_and_solve_different_size() {
         let model_a = build_model(2, 5);
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator_a = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model_a.num_berths(),
             model_a.num_vessels(),
@@ -2148,7 +2142,7 @@ mod tests {
         let model = build_model(2, 5);
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
@@ -2197,10 +2191,7 @@ mod tests {
     }
 
     // Helper function used by test_solver_respects_closing_times and test_solver_respects_closing_times_and_fixed_assignments_together
-    fn build_model_with_closing_times(
-        num_berths: usize,
-        num_vessels: usize,
-    ) -> bollard_model::model::Model<IntegerType> {
+    fn build_model_with_closing_times(num_berths: usize, num_vessels: usize) -> Model<IntegerType> {
         let mut builder = ModelBuilder::<IntegerType>::new(num_berths, num_vessels);
 
         for v in 0..num_vessels {
@@ -2236,7 +2227,7 @@ mod tests {
     fn test_solver_respects_closing_times() {
         let model = build_model_with_closing_times(2, 8);
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2279,7 +2270,7 @@ mod tests {
         let model = builder.build();
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2366,7 +2357,7 @@ mod tests {
         //
         let mut solver_phase1 = BnbSolver::<IntegerType>::new();
         let mut heuristic_builder =
-            EarliestDeadlineFirstBuilder::preallocated(model.num_berths(), model.num_vessels());
+            EdfHeuristic::preallocated(model.num_berths(), model.num_vessels());
         let mut heuristic_evaluator =
             HybridEvaluator::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
 
@@ -2402,7 +2393,7 @@ mod tests {
         // Phase 2: exact BnB with chronological branching, warm-started from phase 1
         //
         let mut solver_phase2 = BnbSolver::<IntegerType>::new();
-        let mut exhaustive_builder = WsptHeuristicBuilder::new();
+        let mut exhaustive_builder = WsptBuilder::new();
         let mut exhaustive_evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2472,7 +2463,7 @@ mod tests {
     fn test_solver_respects_closing_times_and_fixed_assignments_together() {
         let model = build_model_with_closing_times(2, 6);
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
@@ -2524,7 +2515,7 @@ mod tests {
         let mut solver = BnbSolver::<IntegerType>::new();
 
         let mut evaluator = HybridEvaluator::<IntegerType>::preallocated(2, 1);
-        let mut decision_builder = RegretHeuristicBuilder::preallocated(2, 1);
+        let mut decision_builder = RegretBuilder::preallocated(2, 1);
 
         let outcome = solver.solve(
             BnbSearchParams::builder(
@@ -2613,7 +2604,7 @@ mod tests {
         let mut solver = BnbSolver::<IntegerType>::new();
         // Use Chronological to prove it's not just a lucky heuristic guess,
         // but that the availability logic strictly enforces the gap constraints.
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(1, 3);
 
         let outcome = solver.solve(
@@ -2692,7 +2683,7 @@ mod tests {
         let model = builder.build();
 
         let mut solver = BnbSolver::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(1, 2);
 
         let outcome = solver.solve(
@@ -2799,7 +2790,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         // Use Chronological to rely purely on the decision generation/pruning logic, avoiding heuristic luck.
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(2, 2);
 
         let outcome = solver.solve(

--- a/crates/bollard-bnb/src/bnb.rs
+++ b/crates/bollard-bnb/src/bnb.rs
@@ -783,7 +783,7 @@ mod tests {
     use crate::branching::regret::RegretHeuristicBuilder;
     use crate::branching::wspt::WsptHeuristicBuilder;
     use crate::eval::hybrid::HybridEvaluator;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use crate::monitor::no_op::NoOperationMonitor;
     use crate::monitor::solution::SolutionLimitMonitor;
     use crate::{
@@ -930,7 +930,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -976,7 +976,7 @@ mod tests {
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1027,7 +1027,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1048,7 +1048,7 @@ mod tests {
         };
         assert_eq!(sol1.objective_value(), 291);
 
-        let mut evaluator2 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator2 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1085,7 +1085,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1136,7 +1136,7 @@ mod tests {
         let mut solver =
             BnbSolver::<IntegerType>::preallocated(model.num_berths(), model.num_vessels());
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1219,7 +1219,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1281,7 +1281,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1331,7 +1331,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1375,7 +1375,7 @@ mod tests {
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
         for run in 0..2 {
-            let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+            let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
                 model.num_berths(),
                 model.num_vessels(),
             );
@@ -1436,7 +1436,7 @@ mod tests {
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
-        let mut evaluator1 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1456,7 +1456,7 @@ mod tests {
         };
         assert_eq!(sol1.objective_value(), 291);
 
-        let mut evaluator2 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator2 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1489,7 +1489,7 @@ mod tests {
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
         for run in 0..3 {
-            let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+            let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
                 model.num_berths(),
                 model.num_vessels(),
             );
@@ -1552,7 +1552,7 @@ mod tests {
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1587,7 +1587,7 @@ mod tests {
             "stack should be empty after first run"
         );
 
-        let mut evaluator2 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator2 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1642,7 +1642,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1688,7 +1688,7 @@ mod tests {
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
         for i in 0..3 {
-            let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+            let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
                 model.num_berths(),
                 model.num_vessels(),
             );
@@ -1733,7 +1733,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1789,7 +1789,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::default();
+        let mut evaluator = WeightedCompletionTimeEvaluator::default();
 
         let outcome = solver.solve(
             BnbSearchParams::builder(
@@ -1819,7 +1819,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator_cold = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator_cold = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1853,7 +1853,7 @@ mod tests {
             "incumbent upper bound should reflect the installed solution"
         );
 
-        let mut evaluator_warm = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator_warm = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1930,7 +1930,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -1985,7 +1985,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2033,7 +2033,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator1 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2059,7 +2059,7 @@ mod tests {
         assert_eq!(incumbent.upper_bound(), 291);
 
         // We only rely on incumbent here; we still create a fresh evaluator & call solve_with_incumbent
-        let mut evaluator2 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator2 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2089,7 +2089,7 @@ mod tests {
         let model_a = build_model(2, 5);
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator_a = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator_a = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model_a.num_berths(),
             model_a.num_vessels(),
         );
@@ -2117,7 +2117,7 @@ mod tests {
         assert!(solver.stack.is_empty());
 
         let model_b = build_model(2, 6);
-        let mut evaluator_b = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator_b = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model_b.num_berths(),
             model_b.num_vessels(),
         );
@@ -2150,7 +2150,7 @@ mod tests {
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
-        let mut evaluator1 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator1 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2169,7 +2169,7 @@ mod tests {
             _ => panic!("first run should return a solution"),
         };
 
-        let mut evaluator2 = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator2 = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2237,7 +2237,7 @@ mod tests {
         let model = build_model_with_closing_times(2, 8);
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2280,7 +2280,7 @@ mod tests {
 
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2403,7 +2403,7 @@ mod tests {
         //
         let mut solver_phase2 = BnbSolver::<IntegerType>::new();
         let mut exhaustive_builder = WsptHeuristicBuilder::new();
-        let mut exhaustive_evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut exhaustive_evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2473,7 +2473,7 @@ mod tests {
         let model = build_model_with_closing_times(2, 6);
         let mut solver = BnbSolver::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );
@@ -2560,5 +2560,285 @@ mod tests {
                 panic!("Rust Solver returned Unknown.");
             }
         }
+    }
+
+    #[test]
+    fn test_solver_identifies_and_fills_gaps_around_fixed_assignment() {
+        // Scenario:
+        // Berth 0 is the only berth.
+        // Vessel 0 (Fixed): Starts at 20, Duration 20. Occupies [20, 40).
+        // Gap Created: [0, 20).
+        // Vessel 1 (Small): Duration 15. Should fill the gap [0, 15).
+        // Vessel 2 (Large): Duration 25. Cannot fit in gap (max 20). Must go after V0 [40, 65).
+
+        let mut builder = ModelBuilder::<IntegerType>::new(1, 3);
+
+        // All arrive at 0
+        for v in 0..3 {
+            builder
+                .set_vessel_arrival_time(VesselIndex::new(v), 0)
+                .set_vessel_weight(VesselIndex::new(v), 1);
+        }
+
+        // V0: The Obstacle
+        builder.set_vessel_processing_time(
+            VesselIndex::new(0),
+            BerthIndex::new(0),
+            ProcessingTime::some(20),
+        );
+
+        // V1: The Filler (15 < 20)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(1),
+            BerthIndex::new(0),
+            ProcessingTime::some(15),
+        );
+
+        // V2: The Overflow (25 > 20)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(2),
+            BerthIndex::new(0),
+            ProcessingTime::some(25),
+        );
+
+        let model = builder.build();
+
+        // Fix V0 to start at 20
+        let fixed = vec![FixedAssignment::new(
+            20,
+            BerthIndex::new(0),
+            VesselIndex::new(0),
+        )];
+
+        let mut solver = BnbSolver::<IntegerType>::new();
+        // Use Chronological to prove it's not just a lucky heuristic guess,
+        // but that the availability logic strictly enforces the gap constraints.
+        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(1, 3);
+
+        let outcome = solver.solve(
+            BnbSearchParams::builder(
+                &model,
+                &mut builder,
+                &mut evaluator,
+                LogTreeSearchMonitor::default(),
+            )
+            .with_fixed_assignments(&fixed)
+            .build()
+            .unwrap(),
+        );
+
+        let solution = outcome.result().unwrap_optimal();
+
+        println!("Objective: {}", solution.objective_value());
+
+        // Check V0 (Fixed)
+        assert_eq!(
+            solution.start_time_for_vessel(VesselIndex::new(0)),
+            20,
+            "V0 must respect fixed start"
+        );
+
+        // Check V1 (The Filler)
+        let v1_start = solution.start_time_for_vessel(VesselIndex::new(1));
+        assert_eq!(v1_start, 0, "V1 should fit in the gap starting at 0");
+
+        // Check V2 (The Overflow)
+        let v2_start = solution.start_time_for_vessel(VesselIndex::new(2));
+        assert!(
+            v2_start >= 40,
+            "V2 is too big for the gap; must start after V0 finishes (at 40). Got {}",
+            v2_start
+        );
+
+        // Explicitly verify the logic:
+        // If the solver tried to put V2 in the gap, start would be 0.
+        // Since V2 duration is 25, it would end at 25.
+        // V0 starts at 20. 25 > 20 -> Collision.
+        // Therefore, BerthAvailability::earliest_availability worked correctly.
+    }
+
+    #[test]
+    fn test_solver_fills_gap_created_by_maintenance_window() {
+        // Scenario: Maintenance window [20, 40).
+        // V1 (Small): Duration 15. Fits [0, 15).
+        // V2 (Large): Duration 25. Fits [40, 65).
+
+        let mut builder = ModelBuilder::<IntegerType>::new(1, 2);
+
+        builder
+            .set_vessel_arrival_time(VesselIndex::new(0), 0)
+            .set_vessel_weight(VesselIndex::new(0), 1);
+        builder
+            .set_vessel_arrival_time(VesselIndex::new(1), 0)
+            .set_vessel_weight(VesselIndex::new(1), 1);
+
+        // V0: Small (15)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(0),
+            BerthIndex::new(0),
+            ProcessingTime::some(15),
+        );
+        // V1: Large (25)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(1),
+            BerthIndex::new(0),
+            ProcessingTime::some(25),
+        );
+
+        // Add Closing Time (Maintenance) [20, 40)
+        builder.add_berth_closing_time(BerthIndex::new(0), ClosedOpenInterval::new(20, 40));
+
+        let model = builder.build();
+
+        let mut solver = BnbSolver::<IntegerType>::new();
+        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(1, 2);
+
+        let outcome = solver.solve(
+            BnbSearchParams::builder(
+                &model,
+                &mut builder,
+                &mut evaluator,
+                NoOperationMonitor::new(),
+            )
+            .build()
+            .unwrap(),
+        );
+
+        let solution = outcome.result().unwrap_optimal();
+
+        // One vessel must start at 0, the other at 40.
+        let s0 = solution.start_time_for_vessel(VesselIndex::new(0));
+        let s1 = solution.start_time_for_vessel(VesselIndex::new(1));
+
+        // V0 (15) fits in [0, 20).
+        // V1 (25) does NOT fit in [0, 20).
+
+        if s0 == 0 {
+            assert!(
+                s1 >= 40,
+                "If V0 took the gap, V1 must wait until maintenance ends."
+            );
+        } else {
+            // This branch shouldn't happen for optimal because V1 is too big for the gap,
+            // so V1 MUST be at 40, meaning V0 MUST be at 0 to minimize completion time.
+            panic!(
+                "Optimal schedule must place V0 (Small) in the gap. Found V0 at {}",
+                s0
+            );
+        }
+
+        assert_eq!(s0, 0);
+        assert_eq!(s1, 40);
+    }
+
+    #[test]
+    fn test_symmetry_breaking_respects_future_constraints() {
+        // Scenario:
+        // Berth 0: High capacity (Closes at 100).
+        // Berth 1: Low capacity (Closes at 20).
+        // Both are free at T=0.
+
+        // Vessel 0: Small (10). Fits on both.
+        // Vessel 1: Large (50). Only fits on Berth 0.
+
+        // If the symmetry breaker thinks B0 and B1 are identical at T=0 (because V0 takes 10 on both),
+        // it might prune B1 (the "worse" index).
+        // This forces V0 onto B0.
+        // Then V1 has nowhere to go but B0 (after V0 finishes).
+        // V0: [0, 10), V1: [10, 60). Total Cost: 10 + 60 = 70.
+
+        // If symmetry is correctly broken by looking at closing times:
+        // Solver tries V0 on B1.
+        // V0: [0, 10) on B1.
+        // V1: [0, 50) on B0.
+        // Total Cost: 10 + 50 = 60.
+
+        let mut builder = ModelBuilder::<IntegerType>::new(2, 2);
+
+        // V0 and V1 Setup
+        for v in 0..2 {
+            builder
+                .set_vessel_arrival_time(VesselIndex::new(v), 0)
+                .set_vessel_weight(VesselIndex::new(v), 1);
+        }
+
+        // Processing Times
+        // V0 (Small)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(0),
+            BerthIndex::new(0),
+            ProcessingTime::some(10),
+        );
+        builder.set_vessel_processing_time(
+            VesselIndex::new(0),
+            BerthIndex::new(1),
+            ProcessingTime::some(10),
+        ); // Identical PT
+
+        // V1 (Large)
+        builder.set_vessel_processing_time(
+            VesselIndex::new(1),
+            BerthIndex::new(0),
+            ProcessingTime::some(50),
+        );
+        builder.set_vessel_processing_time(
+            VesselIndex::new(1),
+            BerthIndex::new(1),
+            ProcessingTime::some(50),
+        ); // Physics allows it, but constraint won't
+
+        // Closing Times (The Differentiator)
+        // B0 closes at 100
+        builder.add_berth_closing_time(BerthIndex::new(0), ClosedOpenInterval::new(100, 200));
+        // B1 closes at 20
+        builder.add_berth_closing_time(BerthIndex::new(1), ClosedOpenInterval::new(20, 200));
+
+        let model = builder.build();
+
+        let mut solver = BnbSolver::<IntegerType>::new();
+        // Use Chronological to rely purely on the decision generation/pruning logic, avoiding heuristic luck.
+        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(2, 2);
+
+        let outcome = solver.solve(
+            BnbSearchParams::builder(
+                &model,
+                &mut builder,
+                &mut evaluator,
+                LogTreeSearchMonitor::default(), // Use Log monitor to see what's happening if it fails
+            )
+            .build()
+            .unwrap(),
+        );
+
+        let solution = outcome.result().unwrap_optimal();
+        let obj = solution.objective_value();
+
+        println!("Found Objective: {}", obj);
+
+        if obj == 70 {
+            panic!(
+                "Suboptimal solution found (70). The symmetry breaker likely pruned the optimal branch (60) because it ignored the closing time difference between berths."
+            );
+        }
+
+        assert_eq!(
+            obj, 60,
+            "Solver should find the optimal schedule by utilizing the constrained berth for the small vessel."
+        );
+
+        // Optional: verify placement
+        assert_eq!(
+            solution.berth_for_vessel(VesselIndex::new(0)),
+            BerthIndex::new(1),
+            "V0 should take the small berth"
+        );
+        assert_eq!(
+            solution.berth_for_vessel(VesselIndex::new(1)),
+            BerthIndex::new(0),
+            "V1 should take the large berth"
+        );
     }
 }

--- a/crates/bollard-bnb/src/branching/chronological.rs
+++ b/crates/bollard-bnb/src/branching/chronological.rs
@@ -208,7 +208,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -280,7 +280,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
 
         // Evaluator is now actively used by the builder via Decision::try_new
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
 
         let iter = builder.next_decision(&mut eval, &model, &berth_availability, &state);
@@ -313,7 +313,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
 
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = ChronologicalExhaustiveBuilder::new();
         let mut it = builder.next_decision(&mut eval, &model, &berth_availability, &state);
 

--- a/crates/bollard-bnb/src/branching/chronological.rs
+++ b/crates/bollard-bnb/src/branching/chronological.rs
@@ -64,12 +64,12 @@ use std::iter::FusedIterator;
 /// The resulting search space is significantly smaller than the naive full
 /// permutation tree, while still covering all canonical optimal schedules.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
-pub struct ChronologicalExhaustiveBuilder<T> {
+pub struct ChronologicalBuilder<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> ChronologicalExhaustiveBuilder<T> {
-    /// Creates a new `ChronologicalExhaustiveBuilder`.
+impl<T> ChronologicalBuilder<T> {
+    /// Creates a new `ChronologicalBuilder`.
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -85,20 +85,20 @@ impl<T> ChronologicalExhaustiveBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for ChronologicalExhaustiveBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for ChronologicalBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
 {
     type DecisionIterator<'a>
-        = ExhaustiveIter<'a, T, E>
+        = ChronologicalIter<'a, T, E>
     where
         T: 'a,
         E: 'a,
         Self: 'a;
 
     fn name(&self) -> &str {
-        "ChronologicalExhaustiveBuilder"
+        "ChronologicalBuilder"
     }
 
     fn next_decision<'a>(
@@ -108,7 +108,7 @@ where
         berth_availability: &'a BerthAvailability<T>,
         state: &'a SearchState<T>,
     ) -> Self::DecisionIterator<'a> {
-        ExhaustiveIter {
+        ChronologicalIter {
             current_vessel: VesselIndex::new(0),
             current_berth: BerthIndex::new(0),
             berth_availability,
@@ -126,7 +126,7 @@ where
 /// (vessels × berths), skipping already-assigned vessels and yielding only
 /// decisions deemed feasible by the model, availability map, and evaluator.
 #[derive(Debug)]
-pub struct ExhaustiveIter<'a, T, E>
+pub struct ChronologicalIter<'a, T, E>
 where
     T: PrimInt + Signed + MinusOne,
 {
@@ -138,7 +138,7 @@ where
     evaluator: &'a mut E,
 }
 
-impl<'a, T, E> Iterator for ExhaustiveIter<'a, T, E>
+impl<'a, T, E> Iterator for ChronologicalIter<'a, T, E>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -198,7 +198,7 @@ where
     }
 }
 
-impl<'a, T, E> FusedIterator for ExhaustiveIter<'a, T, E>
+impl<'a, T, E> FusedIterator for ChronologicalIter<'a, T, E>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -281,7 +281,7 @@ mod tests {
 
         // Evaluator is now actively used by the builder via Decision::try_new
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
 
         let iter = builder.next_decision(&mut eval, &model, &berth_availability, &state);
         let decisions: Vec<Decision<IntegerType>> = iter.collect();
@@ -314,7 +314,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
 
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = ChronologicalExhaustiveBuilder::new();
+        let mut builder = ChronologicalBuilder::new();
         let mut it = builder.next_decision(&mut eval, &model, &berth_availability, &state);
 
         // Exhaust the iterator

--- a/crates/bollard-bnb/src/branching/decision.rs
+++ b/crates/bollard-bnb/src/branching/decision.rs
@@ -166,6 +166,10 @@ where
         current_free
     };
 
+    if ba.unavailable_intervals(berth_index) != ba.unavailable_intervals(previous_berth) {
+        return false;
+    }
+
     // This uses a custom written, high-performance binary search internally.
     // Even though its fast to call it still needs to load the berth availability data
     // from memory, and call the binary search that is O(log N + K) where N is the number of
@@ -247,6 +251,10 @@ where
     } else {
         current_free
     };
+
+    if ba.unavailable_intervals(berth_index) != ba.unavailable_intervals(previous_berth) {
+        return false;
+    }
 
     // This uses a custom written, high-performance binary search internally.
     // Even though its fast to call it still needs to load the berth availability data
@@ -558,7 +566,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::index::{BerthIndex, VesselIndex};
     use bollard_model::model::ModelBuilder;
     use bollard_model::time::ProcessingTime;
@@ -931,7 +939,7 @@ mod tests {
         assert!(ba.initialize(&model, &[]));
 
         let mut state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         // Assign vessel 0 first
         state.assign_vessel(VesselIndex::new(0), BerthIndex::new(0), 0);
@@ -974,7 +982,7 @@ mod tests {
         assert!(ba.initialize(&model, &[]));
 
         let mut state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         // Make both berths have same free time, ensuring indistinguishable slots
         state.set_berth_free_time(BerthIndex::new(0), 5);
@@ -1033,7 +1041,7 @@ mod tests {
         assert!(ba.initialize(&model, &[]));
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         // None processing time -> decision must be None
         let d_none = Decision::try_new(
@@ -1065,7 +1073,7 @@ mod tests {
         assert!(ba.initialize(&model, &[]));
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         // Ensure a feasible nominal start (arrival=5, berth_free=0 -> nominal=5)
         let v = VesselIndex::new(1);

--- a/crates/bollard-bnb/src/branching/edf.rs
+++ b/crates/bollard-bnb/src/branching/edf.rs
@@ -176,7 +176,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -264,7 +264,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -336,7 +336,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
@@ -389,7 +389,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder

--- a/crates/bollard-bnb/src/branching/edf.rs
+++ b/crates/bollard-bnb/src/branching/edf.rs
@@ -87,11 +87,11 @@ impl<T: Eq> Eq for EdfCandidate<T> {}
 ///
 /// This acts as a "Fail-First" heuristic compatible with chronological search states.
 #[derive(Debug, Clone, Default)]
-pub struct EarliestDeadlineFirstBuilder<T> {
+pub struct EdfHeuristic<T> {
     candidates: Vec<EdfCandidate<T>>,
 }
 
-impl<T> EarliestDeadlineFirstBuilder<T> {
+impl<T> EdfHeuristic<T> {
     pub fn new() -> Self {
         Self {
             candidates: Vec::new(),
@@ -105,7 +105,7 @@ impl<T> EarliestDeadlineFirstBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for EarliestDeadlineFirstBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for EdfHeuristic<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -118,7 +118,7 @@ where
         E: 'a;
 
     fn name(&self) -> &str {
-        "EarliestDeadlineFirst"
+        "EdfHeuristic"
     }
 
     fn next_decision<'a>(
@@ -265,7 +265,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
+        let mut builder = EdfHeuristic::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -337,7 +337,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
+        let mut builder = EdfHeuristic::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
         assert_eq!(
@@ -390,7 +390,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = EarliestDeadlineFirstBuilder::<IntegerType>::new();
+        let mut builder = EdfHeuristic::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)

--- a/crates/bollard-bnb/src/branching/fcfs.rs
+++ b/crates/bollard-bnb/src/branching/fcfs.rs
@@ -241,7 +241,7 @@ impl<'a, T> FusedIterator for FcfsHeuristicIter<'a, T> where T: Copy {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -287,7 +287,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
@@ -334,7 +334,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(1, 2);
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
@@ -367,7 +367,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
@@ -406,7 +406,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -469,7 +469,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder

--- a/crates/bollard-bnb/src/branching/fcfs.rs
+++ b/crates/bollard-bnb/src/branching/fcfs.rs
@@ -117,7 +117,7 @@ where
 /// the same arrival time, it breaks ties by preferring assignments with lower
 /// costs, and further ties are resolved using the natural ordering of `Decision`.
 #[derive(Debug, Clone, Default)]
-pub struct FcfsHeuristicBuilder<T> {
+pub struct FcfsBuilder<T> {
     /// Scratch buffer for candidates.
     ///
     /// We never deallocate this buffer during the lifetime of the builder.
@@ -125,8 +125,8 @@ pub struct FcfsHeuristicBuilder<T> {
     candidates: Vec<FcfsCandidate<T>>,
 }
 
-impl<T> FcfsHeuristicBuilder<T> {
-    /// Creates a new `FcfsHeuristicBuilder` with an empty candidate buffer.
+impl<T> FcfsBuilder<T> {
+    /// Creates a new `FcfsBuilder` with an empty candidate buffer.
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -134,7 +134,7 @@ impl<T> FcfsHeuristicBuilder<T> {
         }
     }
 
-    /// Creates a new `FcfsHeuristicBuilder` with preallocated capacity.
+    /// Creates a new `FcfsBuilder` with preallocated capacity.
     #[inline]
     pub fn preallocated(num_berths: usize, num_vessels: usize) -> Self {
         Self {
@@ -143,20 +143,20 @@ impl<T> FcfsHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for FcfsHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for FcfsBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
 {
     type DecisionIterator<'a>
-        = FcfsHeuristicIter<'a, T>
+        = FcfsIter<'a, T>
     where
         T: 'a,
         E: 'a,
         Self: 'a;
 
     fn name(&self) -> &str {
-        "FirstComeFirstServeBuilder"
+        "FcfsBuilder"
     }
 
     fn next_decision<'a>(
@@ -213,18 +213,18 @@ where
 
         self.candidates.sort_unstable();
 
-        FcfsHeuristicIter {
+        FcfsIter {
             iter: self.candidates.iter(),
         }
     }
 }
 
 /// A lightweight iterator that yields `Decision`s from the FCFS-sorted candidate slice.
-pub struct FcfsHeuristicIter<'a, T> {
+pub struct FcfsIter<'a, T> {
     iter: std::slice::Iter<'a, FcfsCandidate<T>>,
 }
 
-impl<'a, T> Iterator for FcfsHeuristicIter<'a, T>
+impl<'a, T> Iterator for FcfsIter<'a, T>
 where
     T: Copy,
 {
@@ -236,7 +236,7 @@ where
     }
 }
 
-impl<'a, T> FusedIterator for FcfsHeuristicIter<'a, T> where T: Copy {}
+impl<'a, T> FusedIterator for FcfsIter<'a, T> where T: Copy {}
 
 #[cfg(test)]
 mod tests {
@@ -288,7 +288,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
+        let mut builder = FcfsBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
 
@@ -335,7 +335,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(1, 2);
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
+        let mut builder = FcfsBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
 
@@ -368,7 +368,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
+        let mut builder = FcfsBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
         assert_eq!(
@@ -407,7 +407,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
+        let mut builder = FcfsBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -470,7 +470,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = FcfsHeuristicBuilder::<IntegerType>::new();
+        let mut builder = FcfsBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)

--- a/crates/bollard-bnb/src/branching/lpt.rs
+++ b/crates/bollard-bnb/src/branching/lpt.rs
@@ -81,11 +81,11 @@ impl<T: Ord + SolverNumeric> PartialOrd for LptCandidate<T> {
 ///
 /// It prioritizes assignments where the processing time $p_{ij}$ is maximal.
 #[derive(Debug, Clone, Default)]
-pub struct LptHeuristicBuilder<T> {
+pub struct LptBuilder<T> {
     candidates: Vec<LptCandidate<T>>,
 }
 
-impl<T> LptHeuristicBuilder<T> {
+impl<T> LptBuilder<T> {
     pub fn new() -> Self {
         Self {
             candidates: Vec::new(),
@@ -98,7 +98,7 @@ impl<T> LptHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for LptHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for LptBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -111,7 +111,7 @@ where
         E: 'a;
 
     fn name(&self) -> &str {
-        "LptHeuristicBuilder"
+        "LptBuilder"
     }
 
     fn next_decision<'a>(
@@ -188,8 +188,8 @@ mod tests {
     use crate::{
         berth_availability::BerthAvailability,
         branching::decision::{Decision, DecisionBuilder},
-        // Assuming LptHeuristicBuilder is exported or available here
-        branching::lpt::LptHeuristicBuilder,
+        // Assuming LptBuilder is exported or available here
+        branching::lpt::LptBuilder,
         eval::wct::WeightedCompletionTimeEvaluator,
         state::SearchState,
     };
@@ -244,7 +244,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = LptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = LptBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -295,7 +295,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(2, 1);
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = LptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = LptBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut eval, &model, &ba, &state)
             .collect();
@@ -335,7 +335,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(2, 1);
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = LptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = LptBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut eval, &model, &ba, &state)
             .collect();

--- a/crates/bollard-bnb/src/branching/lpt.rs
+++ b/crates/bollard-bnb/src/branching/lpt.rs
@@ -190,7 +190,7 @@ mod tests {
         branching::decision::{Decision, DecisionBuilder},
         // Assuming LptHeuristicBuilder is exported or available here
         branching::lpt::LptHeuristicBuilder,
-        eval::wtft::WeightedFlowTimeEvaluator,
+        eval::wct::WeightedCompletionTimeEvaluator,
         state::SearchState,
     };
     use bollard_model::{
@@ -242,7 +242,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = LptHeuristicBuilder::<IntegerType>::new();
 
@@ -293,7 +293,7 @@ mod tests {
         let mut ba = BerthAvailability::new();
         ba.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(2, 1);
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = LptHeuristicBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -333,7 +333,7 @@ mod tests {
         let mut ba = BerthAvailability::new();
         ba.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(2, 1);
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = LptHeuristicBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder

--- a/crates/bollard-bnb/src/branching/regret.rs
+++ b/crates/bollard-bnb/src/branching/regret.rs
@@ -234,7 +234,7 @@ impl<'a, T: Copy> FusedIterator for RegretHeuristicIter<'a, T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -328,7 +328,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = RegretHeuristicBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -408,7 +408,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = RegretHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);

--- a/crates/bollard-bnb/src/branching/regret.rs
+++ b/crates/bollard-bnb/src/branching/regret.rs
@@ -108,12 +108,12 @@ where
 ///    - If 1 option: `regret = T::max_value()` (Must assign now).
 /// 4. It promotes all options to a global list, sorted by descending regret.
 #[derive(Debug, Clone, Default)]
-pub struct RegretHeuristicBuilder<T> {
+pub struct RegretBuilder<T> {
     candidates: Vec<RegretCandidate<T>>,
     scratch_options: Vec<Decision<T>>,
 }
 
-impl<T> RegretHeuristicBuilder<T> {
+impl<T> RegretBuilder<T> {
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -131,7 +131,7 @@ impl<T> RegretHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for RegretHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for RegretBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -144,7 +144,7 @@ where
         Self: 'a;
 
     fn name(&self) -> &str {
-        "RegretHeuristicBuilder"
+        "RegretBuilder"
     }
 
     fn next_decision<'a>(
@@ -329,7 +329,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = RegretHeuristicBuilder::<IntegerType>::new();
+        let mut builder = RegretBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -409,7 +409,7 @@ mod tests {
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = RegretHeuristicBuilder::<IntegerType>::new();
+        let mut builder = RegretBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
         assert_eq!(

--- a/crates/bollard-bnb/src/branching/slack.rs
+++ b/crates/bollard-bnb/src/branching/slack.rs
@@ -109,12 +109,12 @@ where
 ///    - secondary: ascending `cost_delta` (cheapest first),
 ///    - tertiary: deterministic `Decision` order.
 #[derive(Debug, Clone, Default)]
-pub struct SlackHeuristicBuilder<T> {
+pub struct SlackBuilder<T> {
     candidates: Vec<SlackCandidate<T>>,
     scratch_options: Vec<Decision<T>>,
 }
 
-impl<T> SlackHeuristicBuilder<T> {
+impl<T> SlackBuilder<T> {
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -140,7 +140,7 @@ impl<T> SlackHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for SlackHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for SlackBuilder<T>
 where
     T: SolverNumeric + num_traits::Bounded + SaturatingSubVal,
     E: ObjectiveEvaluator<T>,
@@ -153,7 +153,7 @@ where
         Self: 'a;
 
     fn name(&self) -> &str {
-        "SlackHeuristicBuilder"
+        "SlackBuilder"
     }
 
     fn next_decision<'a>(
@@ -337,7 +337,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = SlackHeuristicBuilder::<IntegerType>::new();
+        let mut builder = SlackBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -445,7 +445,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = SlackHeuristicBuilder::<IntegerType>::new();
+        let mut builder = SlackBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
         assert_eq!(

--- a/crates/bollard-bnb/src/branching/slack.rs
+++ b/crates/bollard-bnb/src/branching/slack.rs
@@ -260,7 +260,7 @@ impl<'a, T: Copy> FusedIterator for SlackHeuristicIter<'a, T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -336,7 +336,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = SlackHeuristicBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -444,7 +444,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = SlackHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);

--- a/crates/bollard-bnb/src/branching/spt.rs
+++ b/crates/bollard-bnb/src/branching/spt.rs
@@ -79,11 +79,11 @@ impl<T: Ord + SolverNumeric> PartialOrd for SptCandidate<T> {
 ///
 /// It prioritizes assignments where the processing time $p_{ij}$ is minimal.
 #[derive(Debug, Clone, Default)]
-pub struct SptHeuristicBuilder<T> {
+pub struct SptBuilder<T> {
     candidates: Vec<SptCandidate<T>>,
 }
 
-impl<T> SptHeuristicBuilder<T> {
+impl<T> SptBuilder<T> {
     pub fn new() -> Self {
         Self {
             candidates: Vec::new(),
@@ -96,7 +96,7 @@ impl<T> SptHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for SptHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for SptBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -109,7 +109,7 @@ where
         E: 'a;
 
     fn name(&self) -> &str {
-        "SptHeuristicBuilder"
+        "SptBuilder"
     }
 
     fn next_decision<'a>(
@@ -190,8 +190,8 @@ mod tests {
     use crate::{
         berth_availability::BerthAvailability,
         branching::decision::{Decision, DecisionBuilder},
-        // Assuming SptHeuristicBuilder is exported or available here
-        branching::spt::SptHeuristicBuilder,
+        // Assuming SptBuilder is exported or available here
+        branching::spt::SptBuilder,
         eval::wct::WeightedCompletionTimeEvaluator,
         state::SearchState,
     };
@@ -246,7 +246,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = SptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = SptBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)
@@ -296,7 +296,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(2, 1);
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = SptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = SptBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut eval, &model, &ba, &state)
             .collect();
@@ -339,7 +339,7 @@ mod tests {
         let state = SearchState::<IntegerType>::new(1, 2);
         let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
-        let mut builder = SptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = SptBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut eval, &model, &ba, &state)
             .collect();

--- a/crates/bollard-bnb/src/branching/spt.rs
+++ b/crates/bollard-bnb/src/branching/spt.rs
@@ -192,7 +192,7 @@ mod tests {
         branching::decision::{Decision, DecisionBuilder},
         // Assuming SptHeuristicBuilder is exported or available here
         branching::spt::SptHeuristicBuilder,
-        eval::wtft::WeightedFlowTimeEvaluator,
+        eval::wct::WeightedCompletionTimeEvaluator,
         state::SearchState,
     };
     use bollard_model::{
@@ -244,7 +244,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = SptHeuristicBuilder::<IntegerType>::new();
 
@@ -294,7 +294,7 @@ mod tests {
         let mut ba = BerthAvailability::new();
         ba.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(2, 1);
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = SptHeuristicBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder
@@ -337,7 +337,7 @@ mod tests {
         let mut ba = BerthAvailability::new();
         ba.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(1, 2);
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut eval = WeightedCompletionTimeEvaluator::<IntegerType>::new();
 
         let mut builder = SptHeuristicBuilder::<IntegerType>::new();
         let decisions: Vec<Decision<IntegerType>> = builder

--- a/crates/bollard-bnb/src/branching/urgency.rs
+++ b/crates/bollard-bnb/src/branching/urgency.rs
@@ -231,7 +231,7 @@ impl<'a, T: Copy> FusedIterator for UrgencyRegretIter<'a, T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -273,7 +273,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = UrgencyRegretBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder

--- a/crates/bollard-bnb/src/branching/urgency.rs
+++ b/crates/bollard-bnb/src/branching/urgency.rs
@@ -93,12 +93,12 @@ where
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct UrgencyRegretBuilder<T> {
+pub struct UrgencyRegretHeuristicBuilder<T> {
     candidates: Vec<UrgencyCandidate<T>>,
     scratch_options: Vec<(Decision<T>, T)>, // (Decision, DecisionSlack)
 }
 
-impl<T> UrgencyRegretBuilder<T> {
+impl<T> UrgencyRegretHeuristicBuilder<T> {
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -116,7 +116,7 @@ impl<T> UrgencyRegretBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for UrgencyRegretBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for UrgencyRegretHeuristicBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -129,7 +129,7 @@ where
         Self: 'a;
 
     fn name(&self) -> &str {
-        "UrgencyRegretBuilder"
+        "UrgencyRegretHeuristicBuilder"
     }
 
     fn next_decision<'a>(
@@ -274,7 +274,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = UrgencyRegretBuilder::<IntegerType>::new();
+        let mut builder = UrgencyRegretHeuristicBuilder::<IntegerType>::new();
 
         let decisions: Vec<Decision<IntegerType>> = builder
             .next_decision(&mut evaluator, &model, &berth_availability, &state)

--- a/crates/bollard-bnb/src/branching/wspt.rs
+++ b/crates/bollard-bnb/src/branching/wspt.rs
@@ -111,12 +111,12 @@ where
 /// This "Best-First" strategy helps the solver find high-quality incumbents early,
 /// maximizing the effectiveness of bound-based pruning.
 #[derive(Debug, Clone, Default)]
-pub struct WsptHeuristicBuilder<T> {
+pub struct WsptBuilder<T> {
     candidates: Vec<WsptCandidate<T>>,
 }
 
-impl<T> WsptHeuristicBuilder<T> {
-    /// Creates a new `WsptHeuristicBuilder` with an empty candidate buffer.
+impl<T> WsptBuilder<T> {
+    /// Creates a new `WsptBuilder` with an empty candidate buffer.
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -124,7 +124,7 @@ impl<T> WsptHeuristicBuilder<T> {
         }
     }
 
-    /// Creates a new `WsptHeuristicBuilder` with a preallocated candidate buffer.
+    /// Creates a new `WsptBuilder` with a preallocated candidate buffer.
     #[inline]
     pub fn preallocated(num_berths: usize, num_vessels: usize) -> Self {
         Self {
@@ -132,7 +132,7 @@ impl<T> WsptHeuristicBuilder<T> {
         }
     }
 
-    /// Creates a new `WsptHeuristicBuilder` with specific capacity.
+    /// Creates a new `WsptBuilder` with specific capacity.
     #[inline]
     pub fn with_capacity(size: usize) -> Self {
         Self {
@@ -141,7 +141,7 @@ impl<T> WsptHeuristicBuilder<T> {
     }
 }
 
-impl<T, E> DecisionBuilder<T, E> for WsptHeuristicBuilder<T>
+impl<T, E> DecisionBuilder<T, E> for WsptBuilder<T>
 where
     T: SolverNumeric,
     E: ObjectiveEvaluator<T>,
@@ -310,7 +310,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = WsptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = WsptBuilder::<IntegerType>::new();
 
         // Generate decisions
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
@@ -363,7 +363,7 @@ mod tests {
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
         let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
-        let mut builder = WsptHeuristicBuilder::<IntegerType>::new();
+        let mut builder = WsptBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);
         assert_eq!(

--- a/crates/bollard-bnb/src/branching/wspt.rs
+++ b/crates/bollard-bnb/src/branching/wspt.rs
@@ -239,7 +239,7 @@ impl<'a, T> FusedIterator for WsptHeuristicIter<'a, T> where T: Copy {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -309,7 +309,7 @@ mod tests {
         let mut berth_availability = BerthAvailability::new();
         berth_availability.initialize(&model, &[]);
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = WsptHeuristicBuilder::<IntegerType>::new();
 
         // Generate decisions
@@ -362,7 +362,7 @@ mod tests {
         berth_availability.initialize(&model, &[]);
 
         let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-        let mut evaluator = WeightedFlowTimeEvaluator::<IntegerType>::new();
+        let mut evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::new();
         let mut builder = WsptHeuristicBuilder::<IntegerType>::new();
 
         let mut iter = builder.next_decision(&mut evaluator, &model, &berth_availability, &state);

--- a/crates/bollard-bnb/src/eval/hybrid.rs
+++ b/crates/bollard-bnb/src/eval/hybrid.rs
@@ -22,28 +22,29 @@
 //! Hybrid objective evaluation and lower‑bound estimation for berth scheduling.
 //! This module provides `HybridEvaluator<T>`, an implementation of `ObjectiveEvaluator`
 //! that blends availability‑aware feasibility checks with a fast, capacity‑sensitive
-//! remaining‑cost estimate. The approach treats maintenance windows and berth release
-//! times as first‑class information and couples them with workload‑driven sequencing
-//! so the bound reflects both temporal constraints and congestion effects in a single
-//! coherent approximation.
+//! remaining‑cost estimate.
 //!
-//! The evaluator operates on already‑adjusted start times and reports infeasible
-//! assignments as `None`, allowing the search to respect structural constraints
-//! rather than masking them with inflated penalties. For bound computation, it reads
-//! the current state’s berth free times and projects when remaining vessels can
-//! actually begin processing. It then organizes the outstanding workload with a
-//! lightweight heap to approximate an order that reduces delay for heavy tasks while
-//! staying consistent with berth availability. This hybrid view tends to dominate
-//! purely availability‑blind or purely weight‑only estimates by capturing when the
-//! system truly becomes capable of servicing the backlog.
+//! # Mathematical Note: Completion Time vs. Flow Time
+//!
+//! This evaluator optimizes **Weighted Completion Time** ($C_j \times w_j$) as a proxy
+//! for **Weighted Flow Time** ($(C_j - r_j) \times w_j$). Since the sum of weighted
+//! arrival times $\sum (r_j \times w_j)$ is a constant, minimizing completion time
+//! yields the exact same schedule as minimizing flow time, but reduces arithmetic
+//! overhead in the solver's hot path (the bounds calculation).
+//!
+//! # Algorithm
+//!
+//! The remaining‑cost estimate blends a feasibility‑aware projection with a
+//! lightweight workload relaxation. It first examines each unassigned vessel
+//! against every berth’s current free time and earliest usable window so that
+//! the best attainable finish time respects closures and deadlines. It then
+//! forms a coarse single‑machine schedule over shortest feasible processing
+//! times, starts it no earlier than the earliest berth release or arrival, and
+//! scales by berth count. Taking the maximum of these two views yields a bound
+//! that stays optimistic yet reacts to maintenance and congestion.
 //!
 //! Internally, small caches help avoid recomputation of per‑berth release times and
-//! per‑vessel workload summaries while keeping behavior deterministic. The design
-//! maintains regularity, ensuring costs do not decrease when completion is delayed,
-//! and it keeps the bound optimistic so pruning remains correct. In practice this
-//! makes the evaluator a dependable default: it is quick to evaluate, sensitive to
-//! maintenance and congestion, and stable across a wide range of instances without
-//! tuning or bespoke heuristics.
+//! per‑vessel workload summaries while keeping behavior deterministic.
 
 use crate::{
     berth_availability::BerthAvailability, eval::evaluator::ObjectiveEvaluator, state::SearchState,
@@ -86,7 +87,6 @@ struct WorkloadJob<T> {
 /// regularity, keeps the estimate availability‑aware, and tends to deliver a
 /// tighter bound in congested settings without sacrificing correctness or
 /// determinism.
-
 #[derive(Debug)]
 pub struct HybridEvaluator<T>
 where

--- a/crates/bollard-bnb/src/eval/mod.rs
+++ b/crates/bollard-bnb/src/eval/mod.rs
@@ -48,5 +48,5 @@
 pub mod evaluator;
 pub mod hybrid;
 pub mod validation;
+pub mod wct;
 pub mod workload;
-pub mod wtft;

--- a/crates/bollard-bnb/src/eval/wct.rs
+++ b/crates/bollard-bnb/src/eval/wct.rs
@@ -19,10 +19,20 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! Weighted flow time evaluation and availability‑aware bounding. This module
-//! implements `WeightedFlowTimeEvaluator<T>`, an `ObjectiveEvaluator` for the
+//! This module implements `WeightedCompletionTimeEvaluator<T>`, an `ObjectiveEvaluator` for the
 //! weighted completion objective, integrating berth availability to keep both
 //! local scoring and global bounds aligned with real operating constraints.
+//!
+//! # Mathematical Note: Completion Time vs. Flow Time
+//!
+//! This evaluator optimizes **Weighted Completion Time** ($C_j \times w_j$) as a proxy
+//! for **Weighted Flow Time** ($(C_j - r_j) \times w_j$). Since the sum of weighted
+//! arrival times $\sum (r_j \times w_j)$ is a constant for any given instance, minimizing
+//! completion time yields the **exact same optimal schedule** as minimizing flow time.
+//! Excluding the subtraction of the arrival time reduces arithmetic overhead in the
+//! solver's hot path and avoids the need to access arrival times during cost evaluation.
+//!
+//! # Algorithm
 //!
 //! Local evaluation treats the provided start time as the actual beginning of
 //! service and computes a weighted completion cost. It reports infeasibility as
@@ -70,7 +80,7 @@ where
     }
 }
 
-/// Evaluator for the weighted flow time objective (sum of weight × completion time),
+/// Evaluator for the weighted completion time objective (sum of weight × completion time),
 /// aware of berth availability for both local scoring and global lower bounds.
 /// It implements `ObjectiveEvaluator` and is suitable wherever a regular objective
 /// is required, meaning costs do not decrease when completion is delayed.
@@ -100,7 +110,7 @@ where
 /// minimize reallocation. This design provides predictable performance and integrates
 /// naturally with availability‑aware branching.
 #[derive(Debug)]
-pub struct WeightedFlowTimeEvaluator<T>
+pub struct WeightedCompletionTimeEvaluator<T>
 where
     T: PrimInt + Signed,
 {
@@ -108,7 +118,7 @@ where
     scratch_vessels: Vec<VesselData<T>>,
 }
 
-impl<T> Default for WeightedFlowTimeEvaluator<T>
+impl<T> Default for WeightedCompletionTimeEvaluator<T>
 where
     T: PrimInt + Signed,
 {
@@ -117,11 +127,11 @@ where
     }
 }
 
-impl<T> WeightedFlowTimeEvaluator<T>
+impl<T> WeightedCompletionTimeEvaluator<T>
 where
     T: PrimInt + Signed,
 {
-    /// Creates a new `WeightedFlowTimeEvaluator` with empty scratch buffers.
+    /// Creates a new `WeightedCompletionTimeEvaluator` with empty scratch buffers.
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -130,7 +140,7 @@ where
         }
     }
 
-    /// Creates a new `WeightedFlowTimeEvaluator` with preallocated scratch buffers.
+    /// Creates a new `WeightedCompletionTimeEvaluator` with preallocated scratch buffers.
     #[inline]
     pub fn preallocated(capacity_berths: usize, capacity_vessels: usize) -> Self {
         Self {
@@ -140,13 +150,13 @@ where
     }
 }
 
-impl<T> ObjectiveEvaluator<T> for WeightedFlowTimeEvaluator<T>
+impl<T> ObjectiveEvaluator<T> for WeightedCompletionTimeEvaluator<T>
 where
     T: SolverNumeric,
 {
     #[inline]
     fn name(&self) -> &str {
-        "WeightedFlowTimeEvaluator"
+        "WeightedCompletionTimeEvaluator"
     }
 
     fn evaluate_vessel_assignment(
@@ -336,187 +346,5 @@ where
 
         let lower_bound = lower_bound_workload.max(lower_bound_independent);
         Some(lower_bound)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::eval::evaluator::ObjectiveEvaluator;
-    use bollard_model::{model::ModelBuilder, time::ProcessingTime};
-
-    type IntegerType = i64;
-
-    fn build_model_waiting() -> Model<IntegerType> {
-        let mut builder = ModelBuilder::<IntegerType>::new(2, 2);
-        builder.set_vessel_arrival_time(VesselIndex::new(0), 5);
-        builder.set_vessel_arrival_time(VesselIndex::new(1), 2);
-        builder.set_vessel_weight(VesselIndex::new(0), 3);
-        builder.set_vessel_weight(VesselIndex::new(1), 4);
-        builder.set_vessel_processing_time(
-            VesselIndex::new(0),
-            BerthIndex::new(0),
-            ProcessingTime::some(7),
-        );
-        builder.set_vessel_processing_time(
-            VesselIndex::new(0),
-            BerthIndex::new(1),
-            ProcessingTime::some(3),
-        );
-        builder.set_vessel_processing_time(
-            VesselIndex::new(1),
-            BerthIndex::new(0),
-            ProcessingTime::none(),
-        );
-        builder.set_vessel_processing_time(
-            VesselIndex::new(1),
-            BerthIndex::new(1),
-            ProcessingTime::some(6),
-        );
-        builder.build()
-    }
-
-    #[test]
-    fn test_name_and_display_debug() {
-        let eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
-        assert_eq!(eval.name(), "WeightedFlowTimeEvaluator");
-
-        let dbg = format!("{:?}", &eval as &dyn ObjectiveEvaluator<IntegerType>);
-        let disp = format!("{}", &eval as &dyn ObjectiveEvaluator<IntegerType>);
-        assert!(dbg.contains("ObjectiveEvaluator(WeightedFlowTimeEvaluator)"));
-        assert!(disp.contains("ObjectiveEvaluator(WeightedFlowTimeEvaluator)"));
-    }
-
-    #[test]
-    fn test_evaluate_respects_waiting_time() {
-        let model = build_model_waiting();
-        let avail = BerthAvailability::new(); // empty availability for basic test
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
-
-        // Vessel 0, Berth 0: arrival=5, proc=7. Ready=4 -> Start=5 -> Finish=12. Cost=36
-        // NOTE: We pass the ACTUAL start time here (e.g. 5)
-        let cost_a = eval.evaluate_vessel_assignment(
-            &model,
-            &avail,
-            VesselIndex::new(0),
-            BerthIndex::new(0),
-            5,
-        );
-        assert_eq!(cost_a, Some(36));
-
-        // Ready=10 -> Start=10 -> Finish=17. Cost=51
-        let cost_b = eval.evaluate_vessel_assignment(
-            &model,
-            &avail,
-            VesselIndex::new(0),
-            BerthIndex::new(0),
-            10,
-        );
-        assert_eq!(cost_b, Some(51));
-    }
-
-    #[test]
-    fn test_lower_bound_independent_projection() {
-        // Test Independent Projection logic.
-        // V1 (Arrival 2, Dur 6, W 4) -> Needs B1.
-        // V0 (Arrival 5, Dur 3 [on B1], W 3) -> Can use B0(7) or B1(3).
-
-        // Calculation:
-        // V1: Best is B1. Start max(2,0)=2. Finish 8. Cost 8*4 = 32.
-        // V0: Best is B1. Start max(5,0)=5. Finish 8. Cost 8*3 = 24.
-        // Total LB = 32 + 24 = 56.
-
-        let model = build_model_waiting();
-        let mut avail = BerthAvailability::new();
-        avail.initialize(&model, &[]);
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
-        let state = SearchState::<IntegerType>::new(model.num_berths(), model.num_vessels());
-
-        let lb = eval.estimate_remaining_cost(&model, &avail, &state);
-
-        assert_eq!(lb, Some(56));
-    }
-}
-
-#[cfg(test)]
-mod more_tests {
-    use super::*;
-    use crate::eval::evaluator::ObjectiveEvaluator;
-    use bollard_core::math::interval::ClosedOpenInterval;
-    use bollard_model::{model::ModelBuilder, time::ProcessingTime};
-
-    type IntegerType = i64;
-
-    #[test]
-    fn test_evaluate_unchecked_matches_checked() {
-        // One vessel, one berth
-        let mut b = ModelBuilder::<IntegerType>::new(1, 1);
-        b.set_vessel_arrival_time(VesselIndex::new(0), 5)
-            .set_vessel_weight(VesselIndex::new(0), 3)
-            .set_vessel_latest_departure_time(VesselIndex::new(0), IntegerType::MAX)
-            .set_vessel_processing_time(
-                VesselIndex::new(0),
-                BerthIndex::new(0),
-                ProcessingTime::some(7),
-            );
-        let model = b.build();
-        let avail = BerthAvailability::new();
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
-
-        let start_time = 5;
-        // Checked
-        let safe = eval.evaluate_vessel_assignment(
-            &model,
-            &avail,
-            VesselIndex::new(0),
-            BerthIndex::new(0),
-            start_time,
-        );
-        assert_eq!(safe, Some(36)); // Start=5, Finish=12, Cost=12*3
-
-        // Unchecked
-        let unsafe_cost = unsafe {
-            ObjectiveEvaluator::<IntegerType>::evaluate_vessel_assignment_unchecked(
-                &eval,
-                &model,
-                &avail,
-                VesselIndex::new(0),
-                BerthIndex::new(0),
-                start_time,
-            )
-        };
-        assert_eq!(unsafe_cost, safe);
-    }
-
-    #[test]
-    fn test_lower_bound_uses_availability_to_jump_maintenance() {
-        // Test that LB uses availability.
-        // V0: Arrival 0, Duration 5.
-        // Berth 0: Closed [0, 10).
-        // If LB ignores availability, it thinks Start=0, Finish=5.
-        // If LB respects availability, it sees Start=10, Finish=15.
-
-        let mut b = ModelBuilder::<IntegerType>::new(1, 1);
-        b.set_vessel_arrival_time(VesselIndex::new(0), 0)
-            .set_vessel_weight(VesselIndex::new(0), 1)
-            .set_vessel_processing_time(
-                VesselIndex::new(0),
-                BerthIndex::new(0),
-                ProcessingTime::some(5),
-            )
-            // Add closure
-            .add_berth_closing_time(BerthIndex::new(0), ClosedOpenInterval::new(0, 10));
-        let model = b.build();
-
-        let mut avail = BerthAvailability::new();
-        avail.initialize(&model, &[]); // Setup closure map
-
-        let mut eval = WeightedFlowTimeEvaluator::<IntegerType>::new();
-        let state = SearchState::new(1, 1);
-
-        let lb = eval.estimate_remaining_cost(&model, &avail, &state);
-
-        // Expected: Start at 10 (after closure), Finish at 15. Cost = 15*1 = 15.
-        assert_eq!(lb, Some(15));
     }
 }

--- a/crates/bollard-bnb/src/eval/workload.rs
+++ b/crates/bollard-bnb/src/eval/workload.rs
@@ -21,26 +21,32 @@
 
 //! Workload‑based lower‑bound evaluation for berth scheduling. This module defines
 //! `WorkloadEvaluator<T>`, an `ObjectiveEvaluator` that derives an optimistic cost
-//! by simulating the remaining workload on the available berths with a lightweight
-//! parallel‑machine model. It reads each berth’s next free time from the current
-//! search state and treats unassigned vessels as immediately available, selecting
-//! for each vessel the fastest feasible processing option across berths to preserve
-//! optimism. The resulting jobs are ordered using a WSPT‑style priority so that heavy
-//! tasks tend to be completed earlier in the simulation, producing a bound that is
-//! sensitive to both capacity and workload mix while remaining safely optimistic.
+//! by simulating the remaining workload on the available berths.
+//!
+//! # Mathematical Note: Completion Time vs. Flow Time
+//!
+//! This evaluator optimizes **Weighted Completion Time** ($C_j \times w_j$) as a proxy
+//! for **Weighted Flow Time** ($(C_j - r_j) \times w_j$). Since the sum of weighted
+//! arrival times $\sum (r_j \times w_j)$ is a constant, minimizing completion time
+//! yields the exact same schedule as minimizing flow time, but reduces arithmetic
+//! overhead in the solver's hot path (the bounds calculation).
+//!
+//! # Algorithm
+//!
+//! The evaluator reads each berth’s next free time from the current search state and
+//! treats unassigned vessels as immediately available. It selects the fastest feasible
+//! processing time for each vessel across all berths to preserve optimism. The
+//! resulting jobs are ordered using a WSPT‑style priority (Smith's Rule) so that
+//! heavy tasks tend to be completed earlier in the simulation.
 //!
 //! Local evaluation interprets the provided start time as the actual beginning of
-//! service and returns the weighted completion cost when the assignment is feasible;
-//! if the vessel cannot be completed by its deadline or has no processing time on
-//! the chosen berth, the result is `None`. For the bound, maintenance windows and
-//! arrivals are relaxed deliberately to keep the estimate below or equal to the true
-//! remaining cost, while berth release times are respected to reflect real capacity
-//! limits. If any remaining vessel is infeasible on all berths, the evaluator returns
-//! `None` to signal that the branch cannot lead to a valid schedule. Saturating
-//! arithmetic is used when composing times and costs to avoid overflow without
-//! violating monotonicity. The implementation favors determinism and low overhead,
-//! with optional preallocation to reduce transient allocations when evaluating many
-//! branches in large instances.
+//! service and returns the weighted completion cost when the assignment is feasible.
+//! For the bound, maintenance windows and arrivals are relaxed to keep the estimate
+//! optimistic, while berth release times are respected to reflect capacity limits.
+//!
+//! Saturating arithmetic is used when composing times and costs to avoid overflow
+//! without violating monotonicity. The implementation favors determinism and low
+//! overhead, with optional preallocation to reduce transient allocations.
 
 use crate::{
     berth_availability::BerthAvailability, eval::evaluator::ObjectiveEvaluator, state::SearchState,
@@ -136,6 +142,17 @@ where
         "WorkloadEvaluator"
     }
 
+    /// Calculates the objective cost for a vessel assignment.
+    ///
+    /// # Mathematical Note
+    ///
+    /// This function calculates **Weighted Completion Time** ($C_j \times w_j$) rather than
+    /// strict **Weighted Flow Time** ($(C_j - r_j) \times w_j$).
+    ///
+    /// Since the term $\sum (r_j \times w_j)$ is constant for a given problem instance, minimizing
+    /// Weighted Completion Time yields the **exact same optimal schedule** as minimizing Weighted
+    /// Flow Time. Excluding the subtraction of the arrival time $r_j$ allows the solver to perform
+    /// fewer arithmetic operations in the hot path.
     fn evaluate_vessel_assignment(
         &mut self,
         model: &Model<T>,
@@ -161,6 +178,17 @@ where
         Some(completion_time.saturating_mul_val(weight))
     }
 
+    /// Calculates the objective cost for a vessel assignment.
+    ///
+    /// # Mathematical Note
+    ///
+    /// This function calculates **Weighted Completion Time** ($C_j \times w_j$) rather than
+    /// strict **Weighted Flow Time** ($(C_j - r_j) \times w_j$).
+    ///
+    /// Since the term $\sum (r_j \times w_j)$ is constant for a given problem instance, minimizing
+    /// Weighted Completion Time yields the **exact same optimal schedule** as minimizing Weighted
+    /// Flow Time. Excluding the subtraction of the arrival time $r_j$ allows the solver to perform
+    /// fewer arithmetic operations in the hot path.
     unsafe fn evaluate_vessel_assignment_unchecked(
         &self,
         model: &Model<T>,

--- a/crates/bollard-bnb/src/portfolio.rs
+++ b/crates/bollard-bnb/src/portfolio.rs
@@ -178,7 +178,7 @@ where
 mod tests {
     use super::*;
     use crate::branching::chronological::ChronologicalExhaustiveBuilder;
-    use crate::eval::wtft::WeightedFlowTimeEvaluator;
+    use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
         model::ModelBuilder,
@@ -228,7 +228,7 @@ mod tests {
 
         // Construct inner solver, builder, and evaluator
         let builder = ChronologicalExhaustiveBuilder::new();
-        let evaluator = WeightedFlowTimeEvaluator::<IntegerType>::preallocated(
+        let evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),
         );

--- a/crates/bollard-bnb/src/portfolio.rs
+++ b/crates/bollard-bnb/src/portfolio.rs
@@ -177,7 +177,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::branching::chronological::ChronologicalExhaustiveBuilder;
+    use crate::branching::chronological::ChronologicalBuilder;
     use crate::eval::wct::WeightedCompletionTimeEvaluator;
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
@@ -227,7 +227,7 @@ mod tests {
         let neighborhoods = StaticTopology::from(&model);
 
         // Construct inner solver, builder, and evaluator
-        let builder = ChronologicalExhaustiveBuilder::new();
+        let builder = ChronologicalBuilder::new();
         let evaluator = WeightedCompletionTimeEvaluator::<IntegerType>::preallocated(
             model.num_berths(),
             model.num_vessels(),

--- a/crates/bollard-ffi/src/bnb.rs
+++ b/crates/bollard-ffi/src/bnb.rs
@@ -29,8 +29,8 @@ use bollard_bnb::{
         wspt::WsptHeuristicBuilder,
     },
     eval::{
-        evaluator::ObjectiveEvaluator, hybrid::HybridEvaluator, workload::WorkloadEvaluator,
-        wtft::WeightedFlowTimeEvaluator,
+        evaluator::ObjectiveEvaluator, hybrid::HybridEvaluator,
+        wct::WeightedCompletionTimeEvaluator, workload::WorkloadEvaluator,
     },
     fixed::FixedAssignment,
     monitor::{
@@ -815,7 +815,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = ChronologicalExhaustiveBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -875,7 +875,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = FcfsHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -935,7 +935,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = RegretHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -995,7 +995,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = SlackHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -1055,7 +1055,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = WsptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -1115,7 +1115,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = SptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -1175,7 +1175,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = LptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,
@@ -1235,7 +1235,7 @@ unsafe fn dispatch_solve(
             BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
         ) => {
             let builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedFlowTimeEvaluator::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
                 solver,

--- a/crates/bollard-ffi/src/bnb.rs
+++ b/crates/bollard-ffi/src/bnb.rs
@@ -23,10 +23,9 @@ use crate::result::BollardFfiSolverResult;
 use bollard_bnb::{
     bnb::BnbSolver,
     branching::{
-        chronological::ChronologicalExhaustiveBuilder, decision::DecisionBuilder,
-        edf::EarliestDeadlineFirstBuilder, fcfs::FcfsHeuristicBuilder, lpt::LptHeuristicBuilder,
-        regret::RegretHeuristicBuilder, slack::SlackHeuristicBuilder, spt::SptHeuristicBuilder,
-        wspt::WsptHeuristicBuilder,
+        chronological::ChronologicalBuilder, decision::DecisionBuilder, edf::EdfHeuristic,
+        fcfs::FcfsBuilder, lpt::LptBuilder, regret::RegretBuilder, slack::SlackBuilder,
+        spt::SptBuilder, urgency::UrgencyRegretHeuristicBuilder, wspt::WsptBuilder,
     },
     eval::{
         evaluator::ObjectiveEvaluator, hybrid::HybridEvaluator,
@@ -592,28 +591,30 @@ impl From<BnbFfiFixedAssignment> for FixedAssignment<i64> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum BnbSolverFfiDecisionBuilderType {
-    ChronologicalExhaustive = 0,
-    FcfsHeuristic = 1,
-    RegretHeuristic = 2,
-    SlackHeuristic = 3,
+    Chronological = 0,
+    Fcfs = 1,
+    Regret = 2,
+    Slack = 3,
     #[default]
-    WsptHeuristic = 4, // We default to WSPT. Its generally the best performing sorting heuristic.
-    SptHeuristic = 5,
-    LptHeuristic = 6,
-    EarliestDeadlineFirst = 7,
+    Wspt = 4, // We default to WSPT. Its generally the best performing sorting heuristic.
+    Spt = 5,
+    Lpt = 6,
+    EdfHeuristic = 7,
+    UrgencyRegretHeuristic = 8,
 }
 
 impl std::fmt::Display for BnbSolverFfiDecisionBuilderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            BnbSolverFfiDecisionBuilderType::ChronologicalExhaustive => "ChronologicalExhaustive",
-            BnbSolverFfiDecisionBuilderType::FcfsHeuristic => "FcfsHeuristic",
-            BnbSolverFfiDecisionBuilderType::RegretHeuristic => "RegretHeuristic",
-            BnbSolverFfiDecisionBuilderType::SlackHeuristic => "SlackHeuristic",
-            BnbSolverFfiDecisionBuilderType::WsptHeuristic => "WsptHeuristic",
-            BnbSolverFfiDecisionBuilderType::SptHeuristic => "SptHeuristic",
-            BnbSolverFfiDecisionBuilderType::LptHeuristic => "LptHeuristic",
-            BnbSolverFfiDecisionBuilderType::EarliestDeadlineFirst => "EarliestDeadlineFirst",
+            BnbSolverFfiDecisionBuilderType::Chronological => "Chronological",
+            BnbSolverFfiDecisionBuilderType::Fcfs => "Fcfs",
+            BnbSolverFfiDecisionBuilderType::Regret => "Regret",
+            BnbSolverFfiDecisionBuilderType::Slack => "Slack",
+            BnbSolverFfiDecisionBuilderType::Wspt => "Wspt",
+            BnbSolverFfiDecisionBuilderType::Spt => "Spt",
+            BnbSolverFfiDecisionBuilderType::Lpt => "Lpt",
+            BnbSolverFfiDecisionBuilderType::EdfHeuristic => "EdfHeuristic",
+            BnbSolverFfiDecisionBuilderType::UrgencyRegretHeuristic => "UrgencyRegretHeuristic",
         };
         write!(f, "{}", name)
     }
@@ -626,7 +627,7 @@ pub enum BnbSolverFfiObjectiveEvaluatorType {
     #[default]
     Hybrid = 0, // Basically the union of Workload and WeightedFlowTime. Just better overall.
     Workload = 1,
-    WeightedFlowTime = 2,
+    WeightedCompletionTime = 2,
 }
 
 impl std::fmt::Display for BnbSolverFfiObjectiveEvaluatorType {
@@ -634,7 +635,7 @@ impl std::fmt::Display for BnbSolverFfiObjectiveEvaluatorType {
         let name = match self {
             BnbSolverFfiObjectiveEvaluatorType::Hybrid => "Hybrid",
             BnbSolverFfiObjectiveEvaluatorType::Workload => "Workload",
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime => "WeightedFlowTime",
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime => "WeightedFlowTime",
         };
         write!(f, "{}", name)
     }
@@ -771,10 +772,10 @@ unsafe fn dispatch_solve(
 
     let outcome = match (builder_type, evaluator_type) {
         (
-            BnbSolverFfiDecisionBuilderType::ChronologicalExhaustive,
+            BnbSolverFfiDecisionBuilderType::Chronological,
             BnbSolverFfiObjectiveEvaluatorType::Hybrid,
         ) => {
-            let builder = ChronologicalExhaustiveBuilder::preallocated(num_berths, num_vessels);
+            let builder = ChronologicalBuilder::preallocated(num_berths, num_vessels);
             let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -791,10 +792,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::ChronologicalExhaustive,
+            BnbSolverFfiDecisionBuilderType::Chronological,
             BnbSolverFfiObjectiveEvaluatorType::Workload,
         ) => {
-            let builder = ChronologicalExhaustiveBuilder::preallocated(num_berths, num_vessels);
+            let builder = ChronologicalBuilder::preallocated(num_berths, num_vessels);
             let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -811,10 +812,334 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::ChronologicalExhaustive,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
+            BnbSolverFfiDecisionBuilderType::Chronological,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
         ) => {
-            let builder = ChronologicalExhaustiveBuilder::preallocated(num_berths, num_vessels);
+            let builder = ChronologicalBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Fcfs, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = FcfsBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Fcfs, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = FcfsBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Fcfs,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = FcfsBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Regret, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = RegretBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Regret, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = RegretBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Regret,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = RegretBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Slack, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = SlackBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Slack, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = SlackBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Slack,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = SlackBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Wspt, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = WsptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Wspt, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = WsptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Wspt,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = WsptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Spt, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = SptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Spt, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = SptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Spt,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = SptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Lpt, BnbSolverFfiObjectiveEvaluatorType::Hybrid) => {
+            let builder = LptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (BnbSolverFfiDecisionBuilderType::Lpt, BnbSolverFfiObjectiveEvaluatorType::Workload) => {
+            let builder = LptBuilder::preallocated(num_berths, num_vessels);
+            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
+
+            let outcome = solve(
+                solver,
+                model,
+                builder,
+                evaluator,
+                solution_limit,
+                time_limit_ms,
+                enable_log,
+                initial_solution,
+                fixed_assignments, // With fixed assignments
+            );
+            BnbSolverFfiOutcome::from(outcome)
+        }
+        (
+            BnbSolverFfiDecisionBuilderType::Lpt,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
+        ) => {
+            let builder = LptBuilder::preallocated(num_berths, num_vessels);
             let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -831,10 +1156,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::FcfsHeuristic,
+            BnbSolverFfiDecisionBuilderType::EdfHeuristic,
             BnbSolverFfiObjectiveEvaluatorType::Hybrid,
         ) => {
-            let builder = FcfsHeuristicBuilder::preallocated(num_berths, num_vessels);
+            let builder = EdfHeuristic::preallocated(num_berths, num_vessels);
             let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -851,10 +1176,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::FcfsHeuristic,
+            BnbSolverFfiDecisionBuilderType::EdfHeuristic,
             BnbSolverFfiObjectiveEvaluatorType::Workload,
         ) => {
-            let builder = FcfsHeuristicBuilder::preallocated(num_berths, num_vessels);
+            let builder = EdfHeuristic::preallocated(num_berths, num_vessels);
             let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -871,10 +1196,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::FcfsHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
+            BnbSolverFfiDecisionBuilderType::EdfHeuristic,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
         ) => {
-            let builder = FcfsHeuristicBuilder::preallocated(num_berths, num_vessels);
+            let builder = EdfHeuristic::preallocated(num_berths, num_vessels);
             let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -891,10 +1216,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::RegretHeuristic,
+            BnbSolverFfiDecisionBuilderType::UrgencyRegretHeuristic,
             BnbSolverFfiObjectiveEvaluatorType::Hybrid,
         ) => {
-            let builder = RegretHeuristicBuilder::preallocated(num_berths, num_vessels);
+            let builder = UrgencyRegretHeuristicBuilder::preallocated(num_berths, num_vessels);
             let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -911,10 +1236,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::RegretHeuristic,
+            BnbSolverFfiDecisionBuilderType::UrgencyRegretHeuristic,
             BnbSolverFfiObjectiveEvaluatorType::Workload,
         ) => {
-            let builder = RegretHeuristicBuilder::preallocated(num_berths, num_vessels);
+            let builder = UrgencyRegretHeuristicBuilder::preallocated(num_berths, num_vessels);
             let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -931,310 +1256,10 @@ unsafe fn dispatch_solve(
             BnbSolverFfiOutcome::from(outcome)
         }
         (
-            BnbSolverFfiDecisionBuilderType::RegretHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
+            BnbSolverFfiDecisionBuilderType::UrgencyRegretHeuristic,
+            BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime,
         ) => {
-            let builder = RegretHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SlackHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Hybrid,
-        ) => {
-            let builder = SlackHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SlackHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Workload,
-        ) => {
-            let builder = SlackHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SlackHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
-        ) => {
-            let builder = SlackHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::WsptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Hybrid,
-        ) => {
-            let builder = WsptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::WsptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Workload,
-        ) => {
-            let builder = WsptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::WsptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
-        ) => {
-            let builder = WsptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Hybrid,
-        ) => {
-            let builder = SptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Workload,
-        ) => {
-            let builder = SptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::SptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
-        ) => {
-            let builder = SptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::LptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Hybrid,
-        ) => {
-            let builder = LptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::LptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::Workload,
-        ) => {
-            let builder = LptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::LptHeuristic,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
-        ) => {
-            let builder = LptHeuristicBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::EarliestDeadlineFirst,
-            BnbSolverFfiObjectiveEvaluatorType::Hybrid,
-        ) => {
-            let builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::EarliestDeadlineFirst,
-            BnbSolverFfiObjectiveEvaluatorType::Workload,
-        ) => {
-            let builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
-            let evaluator = WorkloadEvaluator::preallocated(num_berths, num_vessels);
-
-            let outcome = solve(
-                solver,
-                model,
-                builder,
-                evaluator,
-                solution_limit,
-                time_limit_ms,
-                enable_log,
-                initial_solution,
-                fixed_assignments, // With fixed assignments
-            );
-            BnbSolverFfiOutcome::from(outcome)
-        }
-        (
-            BnbSolverFfiDecisionBuilderType::EarliestDeadlineFirst,
-            BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime,
-        ) => {
-            let builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
+            let builder = UrgencyRegretHeuristicBuilder::preallocated(num_berths, num_vessels);
             let evaluator = WeightedCompletionTimeEvaluator::preallocated(num_berths, num_vessels);
 
             let outcome = solve(
@@ -1761,39 +1786,31 @@ mod tests {
     #[test]
     fn test_decision_builder_type_display() {
         assert_eq!(
+            format!("{}", BnbSolverFfiDecisionBuilderType::Chronological),
+            "Chronological"
+        );
+        assert_eq!(format!("{}", BnbSolverFfiDecisionBuilderType::Fcfs), "Fcfs");
+        assert_eq!(
+            format!("{}", BnbSolverFfiDecisionBuilderType::Regret),
+            "Regret"
+        );
+        assert_eq!(
+            format!("{}", BnbSolverFfiDecisionBuilderType::Slack),
+            "Slack"
+        );
+        assert_eq!(format!("{}", BnbSolverFfiDecisionBuilderType::Wspt), "Wspt");
+        assert_eq!(format!("{}", BnbSolverFfiDecisionBuilderType::Spt), "Spt");
+        assert_eq!(format!("{}", BnbSolverFfiDecisionBuilderType::Lpt), "Lpt");
+        assert_eq!(
+            format!("{}", BnbSolverFfiDecisionBuilderType::EdfHeuristic),
+            "EdfHeuristic"
+        );
+        assert_eq!(
             format!(
                 "{}",
-                BnbSolverFfiDecisionBuilderType::ChronologicalExhaustive
+                BnbSolverFfiDecisionBuilderType::UrgencyRegretHeuristic
             ),
-            "ChronologicalExhaustive"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::FcfsHeuristic),
-            "FcfsHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::RegretHeuristic),
-            "RegretHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::SlackHeuristic),
-            "SlackHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::WsptHeuristic),
-            "WsptHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::SptHeuristic),
-            "SptHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::LptHeuristic),
-            "LptHeuristic"
-        );
-        assert_eq!(
-            format!("{}", BnbSolverFfiDecisionBuilderType::EarliestDeadlineFirst),
-            "EarliestDeadlineFirst"
+            "UrgencyRegretHeuristic"
         );
     }
 
@@ -1808,7 +1825,10 @@ mod tests {
             "Workload"
         );
         assert_eq!(
-            format!("{}", BnbSolverFfiObjectiveEvaluatorType::WeightedFlowTime),
+            format!(
+                "{}",
+                BnbSolverFfiObjectiveEvaluatorType::WeightedCompletionTime
+            ),
             "WeightedFlowTime"
         );
     }

--- a/crates/bollard-ffi/src/solution.rs
+++ b/crates/bollard-ffi/src/solution.rs
@@ -20,6 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use bollard_model::index::{BerthIndex, VesselIndex};
+use bollard_model::model::Model;
 use bollard_model::solution::Solution;
 
 /// Creates a new `Solution`.
@@ -89,11 +90,38 @@ pub unsafe extern "C" fn bollard_solution_objective(ptr: *const Solution<i64>) -
     (&*ptr).objective_value()
 }
 
+/// Accesses the weighted total flow time of the solution.
+///
+/// # Panics
+///
+/// This function will panic if `ptr` or `model` is null.
+///
+/// # Safety
+///
+/// The caller must ensure that `ptr` is a valid pointer to a `Solution`
+/// and `model` is a valid pointer to a `Model`.
+#[no_mangle]
+pub unsafe extern "C" fn bollard_solution_weighted_total_flow_time(
+    ptr: *const Solution<i64>,
+    model: *const Model<i64>,
+) -> i64 {
+    assert!(
+        !ptr.is_null(),
+        "called `bollard_solution_weighted_total_flow_time` with `ptr` as null pointer"
+    );
+    assert!(
+        !model.is_null(),
+        "called `bollard_solution_weighted_total_flow_time` with `model` as null pointer"
+    );
+    (&*ptr).weighted_total_flow_time(&*model)
+}
+
 /// Accesses the number of vessels in the solution.
 ///
 /// # Panics
 ///
 /// This function will panic if `ptr` is null.
+/// Panics may also occur if the solution does not belong to the given model.
 ///
 /// # Safety
 ///

--- a/crates/bollard-ls/benches/decoder_benchmark.rs
+++ b/crates/bollard-ls/benches/decoder_benchmark.rs
@@ -122,7 +122,7 @@ where
     T: SolverNumeric,
 {
     let weighted_flow_time =
-        shared::calculate_weighted_flow_time(model, vessel_index, berth_index, start_time)?;
+        shared::calculate_weighted_completion_time(model, vessel_index, berth_index, start_time)?;
 
     Some(Evaluation::new(weighted_flow_time, weighted_flow_time))
 }

--- a/crates/bollard-ls/benches/decoder_benchmark.rs
+++ b/crates/bollard-ls/benches/decoder_benchmark.rs
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use bollard_bnb::bnb::BnbSolver;
-use bollard_bnb::branching::edf::EarliestDeadlineFirstBuilder;
+use bollard_bnb::branching::edf::EdfHeuristic;
 use bollard_bnb::eval::hybrid::HybridEvaluator;
 use bollard_bnb::monitor::solution::SolutionLimitMonitor;
 use bollard_bnb::params::BnbSearchParams;
@@ -88,7 +88,7 @@ fn find_feasible_solution(model: &Model<i64>) -> Solution<i64> {
     let num_berths = model.num_berths();
 
     let mut bnb_solver = BnbSolver::preallocated(num_berths, num_vessels);
-    let mut builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
+    let mut builder = EdfHeuristic::preallocated(num_berths, num_vessels);
     let mut evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
     let solution_limit_monitor = SolutionLimitMonitor::new(1);
 

--- a/crates/bollard-ls/src/decoder.rs
+++ b/crates/bollard-ls/src/decoder.rs
@@ -604,7 +604,7 @@ mod tests {
     where
         T: SolverNumeric,
     {
-        let weighted_flow_time = crate::meta::shared::calculate_weighted_flow_time(
+        let weighted_flow_time = crate::meta::shared::calculate_weighted_completion_time(
             model,
             vessel_index,
             berth_index,

--- a/crates/bollard-ls/src/engine.rs
+++ b/crates/bollard-ls/src/engine.rs
@@ -387,8 +387,8 @@ mod tests {
         result::LocalSearchTerminationReason,
     };
     use bollard_bnb::{
-        bnb::BnbSolver, branching::edf::EarliestDeadlineFirstBuilder,
-        eval::hybrid::HybridEvaluator, params::BnbSearchParams,
+        bnb::BnbSolver, branching::edf::EdfHeuristic, eval::hybrid::HybridEvaluator,
+        params::BnbSearchParams,
     };
     use bollard_model::{
         index::{BerthIndex, VesselIndex},
@@ -701,7 +701,7 @@ mod tests {
         let num_berths = model.num_berths();
 
         let mut bnb_solver = BnbSolver::preallocated(num_berths, num_vessels);
-        let mut builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
+        let mut builder = EdfHeuristic::preallocated(num_berths, num_vessels);
         let mut evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
         let solution_limit_monitor = bollard_bnb::monitor::solution::SolutionLimitMonitor::new(1);
 

--- a/crates/bollard-ls/src/meta/guided_local_search.rs
+++ b/crates/bollard-ls/src/meta/guided_local_search.rs
@@ -532,8 +532,12 @@ where
         berth_index: BerthIndex,
         start_time: T,
     ) -> Option<super::metaheuristic::Evaluation<T>> {
-        let weigted_flow_time =
-            shared::calculate_weighted_flow_time(model, vessel_index, berth_index, start_time)?;
+        let weigted_flow_time = shared::calculate_weighted_completion_time(
+            model,
+            vessel_index,
+            berth_index,
+            start_time,
+        )?;
 
         // Fast path: no penalty or degenerate lambda
         if self.lambda == 0.0 || !self.lambda.is_finite() {
@@ -574,7 +578,7 @@ where
         start_time: T,
     ) -> Option<super::metaheuristic::Evaluation<T>> {
         let weigted_flow_time = unsafe {
-            shared::calculate_weighted_flow_time_unchecked(
+            shared::calculate_weighted_completion_time_unchecked(
                 model,
                 vessel_index,
                 berth_index,

--- a/crates/bollard-ls/src/meta/metaheuristic.rs
+++ b/crates/bollard-ls/src/meta/metaheuristic.rs
@@ -50,7 +50,7 @@ pub struct Evaluation<T> {
     pub score: T,
 
     /// The actual cost to be added to the Schedule's objective value.
-    /// This represents the physical/business cost (e.g., Weighted Flow Time).
+    /// This represents the physical/business cost.
     pub objective_delta: T,
 }
 
@@ -97,8 +97,12 @@ where
         berth_index: BerthIndex,
         start_time: T,
     ) -> Option<Evaluation<T>> {
-        let weighted_flow_time =
-            shared::calculate_weighted_flow_time(model, vessel_index, berth_index, start_time)?;
+        let weighted_flow_time = shared::calculate_weighted_completion_time(
+            model,
+            vessel_index,
+            berth_index,
+            start_time,
+        )?;
         Some(Evaluation::new(weighted_flow_time, weighted_flow_time))
     }
 
@@ -116,7 +120,7 @@ where
         start_time: T,
     ) -> Option<Evaluation<T>> {
         let weighted_flow_time = unsafe {
-            shared::calculate_weighted_flow_time_unchecked(
+            shared::calculate_weighted_completion_time_unchecked(
                 model,
                 vessel_index,
                 berth_index,

--- a/crates/bollard-ls/src/meta/shared.rs
+++ b/crates/bollard-ls/src/meta/shared.rs
@@ -25,14 +25,24 @@ use bollard_model::{
 };
 use bollard_search::num::SolverNumeric;
 
-/// Calculates the weighted flow time cost for a vessel assigned to a berth at a given start time.
+/// Calculates the weighted completion time cost for a vessel assigned to a berth at a given start time.
+///
+/// # Mathematical Note
+///
+/// This function calculates **Weighted Completion Time** ($C_j \times w_j$) rather than
+/// strict **Weighted Flow Time** ($(C_j - r_j) \times w_j$).
+///
+/// Since the term $\sum (r_j \times w_j)$ is constant for a given problem instance, minimizing
+/// Weighted Completion Time yields the **exact same optimal schedule** as minimizing Weighted
+/// Flow Time. Excluding the subtraction of the arrival time $r_j$ allows the solver to perform
+/// fewer arithmetic operations in the hot path.
 ///
 /// # Panics
 ///
 /// In debug builds, this function will panic if `vessel_index` is not within `0..model.num_vessels()`
 /// or if `berth_index` is not within `0..model.num_berths()`.
 #[inline(always)]
-pub fn calculate_weighted_flow_time<T>(
+pub fn calculate_weighted_completion_time<T>(
     model: &Model<T>,
     vessel_index: VesselIndex,
     berth_index: BerthIndex,
@@ -43,14 +53,14 @@ where
 {
     debug_assert!(
         vessel_index.get() < model.num_vessels(),
-        "called `calculate_weighted_flow_time` with vessel index out of bounds: the len is {} but the index is {}",
+        "called `calculate_weighted_completion_time` with vessel index out of bounds: the len is {} but the index is {}",
         model.num_vessels(),
         vessel_index.get()
     );
 
     debug_assert!(
         berth_index.get() < model.num_berths(),
-        "called `calculate_weighted_flow_time` with berth index out of bounds: the len is {} but the index is {}",
+        "called `calculate_weighted_completion_time` with berth index out of bounds: the len is {} but the index is {}",
         model.num_berths(),
         berth_index.get()
     );
@@ -73,7 +83,17 @@ where
     Some(completion_time.saturating_mul_val(weight))
 }
 
-/// Calculates the weighted flow time cost for a vessel assigned to a berth at a given start time.
+/// Calculates the weighted completion time cost for a vessel assigned to a berth at a given start time.
+///
+/// # Mathematical Note
+///
+/// This function calculates **Weighted Completion Time** ($C_j \times w_j$) rather than
+/// strict **Weighted Flow Time** ($(C_j - r_j) \times w_j$).
+///
+/// Since the term $\sum (r_j \times w_j)$ is constant for a given problem instance, minimizing
+/// Weighted Completion Time yields the **exact same optimal schedule** as minimizing Weighted
+/// Flow Time. Excluding the subtraction of the arrival time $r_j$ allows the solver to perform
+/// fewer arithmetic operations in the hot path.
 ///
 /// # Panics
 ///
@@ -85,7 +105,7 @@ where
 /// The caller must ensure that `vessel_index` is within `0..model.num_vessels()` and
 /// `berth_index` is within `0..model.num_berths()`.
 #[inline(always)]
-pub unsafe fn calculate_weighted_flow_time_unchecked<T>(
+pub unsafe fn calculate_weighted_completion_time_unchecked<T>(
     model: &Model<T>,
     vessel_index: VesselIndex,
     berth_index: BerthIndex,
@@ -96,14 +116,14 @@ where
 {
     debug_assert!(
         vessel_index.get() < model.num_vessels(),
-        "called `calculate_weighted_flow_time_unchecked` with vessel index out of bounds: the len is {} but the index is {}",
+        "called `calculate_weighted_completion_time_unchecked` with vessel index out of bounds: the len is {} but the index is {}",
         model.num_vessels(),
         vessel_index.get()
     );
 
     debug_assert!(
         berth_index.get() < model.num_berths(),
-        "called `calculate_weighted_flow_time_unchecked` with berth index out of bounds: the len is {} but the index is {}",
+        "called `calculate_weighted_completion_time_unchecked` with berth index out of bounds: the len is {} but the index is {}",
         model.num_berths(),
         berth_index.get()
     );

--- a/crates/bollard-model/src/solution.rs
+++ b/crates/bollard-model/src/solution.rs
@@ -31,7 +31,11 @@
 //! Like the `Model`, the `Solution` uses a Structure of Arrays (SoA) layout where data
 //! is indexed directly by `VesselIndex`.
 
-use crate::index::{BerthIndex, VesselIndex};
+use crate::{
+    index::{BerthIndex, VesselIndex},
+    model::Model,
+};
+use bollard_core::num::constants;
 use num_traits::{PrimInt, Signed};
 
 /// The final solution to the Berth Allocation Problem.
@@ -223,6 +227,32 @@ where
     #[inline]
     pub fn objective_value_mut(&mut self) -> &mut T {
         &mut self.objective_value
+    }
+
+    /// Calculates the weighted total flow time of the solution.
+    #[inline]
+    pub fn weighted_total_flow_time(&self, model: &Model<T>) -> T
+    where
+        T: constants::MinusOne,
+    {
+        let mut total = T::zero();
+
+        for (i, _berth) in self.berths.iter().enumerate() {
+            let vessel = VesselIndex::new(i);
+            let start_time = self.start_times[i];
+
+            let arrival = model.vessel_arrival_time(vessel);
+            let proc_time_pt = model.vessel_shortest_processing_time(vessel);
+            let proc_time = proc_time_pt.unwrap_or(T::zero());
+            let weight = model.vessel_weight(vessel);
+
+            let completion = start_time + proc_time;
+            let flow_time = completion - arrival;
+
+            total = total + weight * flow_time;
+        }
+
+        total
     }
 
     /// Overwrites this solution with data from another solution.

--- a/crates/bollard-solver/src/opening.rs
+++ b/crates/bollard-solver/src/opening.rs
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use bollard_bnb::{
-    bnb::BnbSolver, branching::edf::EarliestDeadlineFirstBuilder, eval::hybrid::HybridEvaluator,
+    bnb::BnbSolver, branching::edf::EdfHeuristic, eval::hybrid::HybridEvaluator,
     monitor::solution::SolutionLimitMonitor, params::BnbSearchParams,
 };
 use bollard_model::{model::Model, solution::Solution};
@@ -38,7 +38,7 @@ where
     let num_berths = model.num_berths();
 
     let mut bnb_solver = BnbSolver::preallocated(num_berths, num_vessels);
-    let mut builder = EarliestDeadlineFirstBuilder::preallocated(num_berths, num_vessels);
+    let mut builder = EdfHeuristic::preallocated(num_berths, num_vessels);
     let mut evaluator = HybridEvaluator::preallocated(num_berths, num_vessels);
     let solution_limit_monitor = SolutionLimitMonitor::new(1);
 

--- a/crates/bollard-solver/src/solver.rs
+++ b/crates/bollard-solver/src/solver.rs
@@ -346,7 +346,7 @@ mod tests {
     use super::*;
     use crate::opening;
     use bollard_bnb::{
-        branching::regret::RegretHeuristicBuilder, eval::hybrid::HybridEvaluator,
+        branching::regret::RegretBuilder, eval::hybrid::HybridEvaluator,
         portfolio::BnbPortfolioSolver,
     };
     use bollard_ls::{
@@ -398,10 +398,7 @@ mod tests {
         let neighborhoods = StaticTopology::from(&model);
 
         let first_solver = BnbPortfolioSolver::new(
-            RegretHeuristicBuilder::<IntegerType>::preallocated(
-                model.num_berths(),
-                model.num_vessels(),
-            ),
+            RegretBuilder::<IntegerType>::preallocated(model.num_berths(), model.num_vessels()),
             HybridEvaluator::preallocated(model.num_berths(), model.num_vessels()),
         );
 


### PR DESCRIPTION
This pull request refactors several branching heuristics and evaluators in the `bollard-bnb` crate, standardizing naming conventions and updating evaluator usage. It replaces older builder and iterator types with new, consistently named versions, and switches from the `WeightedFlowTimeEvaluator` to the `WeightedCompletionTimeEvaluator` throughout the codebase. Additionally, a new berth availability check is added to the decision logic to improve correctness. These changes affect both implementation and tests, ensuring consistency and improved maintainability.

### Branching Heuristic Refactoring

* Renamed builder and iterator types for chronological, EDF, and FCFS heuristics to use more concise and consistent names (`ChronologicalBuilder`, `EdfHeuristic`, `FcfsBuilder`, and their respective iterators).

### Evaluator Standardization

* Replaced all usages of `WeightedFlowTimeEvaluator` with `WeightedCompletionTimeEvaluator` in implementation and test code for all branching modules.

### Decision Logic Enhancement

* Added a berth availability interval equality check to the decision logic, improving correctness by ensuring decisions only proceed when berth intervals match.

### Benchmark Update

* Updated the benchmark to use the new builder and evaluator types for EDF, ensuring consistency with the refactored implementation.

### Test Updates

* Updated all affected tests to use the new builder and evaluator types, maintaining test coverage and ensuring the refactor did not break existing functionality. 